### PR TITLE
Create MIT LICENSE, Copyright 2021 Raku community

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Raku community
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -47,3 +47,7 @@ let g:raku_unicode_abbrevs = 1
 [pathogen]: https://github.com/tpope/vim-pathogen
 [vim-plug]: https://github.com/junegunn/vim-plug
 [vundle]: https://github.com/gmarik/Vundle.vim
+
+## License
+
+This project is available under the [MIT License](LICENSE.md).


### PR DESCRIPTION
Closes #6.

For choice of MIT license, see poll on issue #6.

For "Raku community", I copied what was in use by the most recent other Raku/* project that doesn't use "The Perl Foundation" or "The Free Software Foundation" (neither of which seems correct here). Unfortunately, that is from a little-known project called github.com/Raku/setup-raku/. Fortunately, it's by Shoichi Kaji, who has a fair amount of experience w/ project management. That being said, if there is any objection it's fine by me to modify it or request a change.