### PR TITLE
Fix file search (gf, [I, etc: path & suffixesadd settings)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ Improved support for Raku in Vim.
 
 ## Installation
 
-Once installed, all files ending in `.raku`, `.rakudoc`, and `.rakutest` (and
-also `.pl6`, `.pm6`, `.p6`, and `.t6` for legacy purposes) will make use of the
-plugin's features.
+Once installed, all files ending in `.raku`, `.rakumod`, `.rakudoc`,
+and `.rakutest` (and also `.pl6`, `.pm6`, `.p6`, and `.t6` for legacy
+purposes) will make use of the plugin's features.
 
 ### With a plugin manager
 

--- a/ftplugin/raku.vim
+++ b/ftplugin/raku.vim
@@ -27,7 +27,7 @@ setlocal commentstring=#%s
 "---------------------------------------------
 setlocal include=\\<\\(use\\\|require\\)\\>
 setlocal includeexpr=substitute(v:fname,'::','/','g')
-setlocal suffixesadd=.pm6,.pm,.raku,.rakutest,.t6
+setlocal suffixesadd=.rakumod,.rakudoc,.pm6,.pm
 setlocal define=[^A-Za-z_]
 
 " The following line changes a global variable but is necessary to make
@@ -38,39 +38,23 @@ setlocal define=[^A-Za-z_]
 set isfname+=:
 setlocal iskeyword=@,48-57,_,192-255,-
 
-" Set this once, globally.
-if !exists("perlpath")
-    if executable("perl6")
-        try
-            if &shellxquote != '"'
-                let perlpath = system('perl6 -e  "@*INC.join(q/,/).say"')
-            else
-                let perlpath = system("perl6 -e  '@*INC.join(q/,/).say'")
-            endif
-            let perlpath = substitute(perlpath,',.$',',,','')
-        catch /E145:/
-            let perlpath = ".,,"
-        endtry
-    else
-        " If we can't call perl to get its path, just default to using the
-        " current directory and the directory of the current file.
-        let perlpath = ".,,"
-    endif
-endif
+" Raku exposes its CompUnits through $*REPO, but mapping module names to
+" compunit paths is nontrivial. Probably it's more convenient to rely on
+" people using zef, which has a handy store of sources for modules it has
+" installed.
+func s:compareReverseFtime(a, b)
+    let atime = getftime(a:a)
+    let btime = getftime(a:b)
+    return atime > btime ? -1 : atime == btime ? 0 : 1
+endfunc
 
-" Append perlpath to the existing path value, if it is set.  Since we don't
-" use += to do it because of the commas in perlpath, we have to handle the
-" global / local settings, too.
-if &l:path == ""
-    if &g:path == ""
-        let &l:path=perlpath
-    else
-        let &l:path=&g:path.",".perlpath
-    endif
-else
-    let &l:path=&l:path.",".perlpath
+let &l:path = "lib,."
+if exists('$RAKULIB')
+    let &l:path = &l:path . "," . $RAKULIB
 endif
-"---------------------------------------------
+let &l:path = &l:path . "," . join(
+            \ sort(glob("~/.zef/store/*/*/lib", 0, 1), "s:compareReverseFtime"),
+            \ ',')
 
 " Convert ascii-based ops into their single-character unicode equivalent
 if get(g:, 'raku_unicode_abbrevs', 0)


### PR DESCRIPTION
Closes #12

This is a stripped down and improved version of the patch in #12, so
credit belongs to @eiro and @zostay for the main idea.

After this patch, 'gf' for example will search:
- ./lib
- .
- $RAKULIB
- ~/.zef/store/*/*/lib (sorted in reverse directory mtime)

A search for Foo::Bar will look in those lib dirs for one of
Foo/Bar.{rakumod,rakudoc,pm6,pm}.