### PR TITLE
Remove g:raku_unicode_abbrevs feature

### DIFF
--- a/doc/vim-raku.txt
+++ b/doc/vim-raku.txt
@@ -86,7 +86,6 @@ based operators into their single-character Unicode equivalent. >
 	iabbrev <buffer> (atomic) ⚛
 	iabbrev <buffer> (cont) ∋
 	iabbrev <buffer> (elem) ∈
-	iabbrev <buffer> * ×
 	iabbrev <buffer> **0 ⁰
 	iabbrev <buffer> **1 ¹
 	iabbrev <buffer> **2 ²
@@ -98,7 +97,8 @@ based operators into their single-character Unicode equivalent. >
 	iabbrev <buffer> **8 ⁸
 	iabbrev <buffer> **9 ⁹
 	iabbrev <buffer> ... …
-	iabbrev <buffer> / ÷
+	iabbrev <buffer> *+ ×
+	iabbrev <buffer> /+ ÷
 	iabbrev <buffer> << «
 	iabbrev <buffer> <<[=]<< «=«
 	iabbrev <buffer> <<[=]>> «=»

--- a/ftplugin/raku.vim
+++ b/ftplugin/raku.vim
@@ -56,68 +56,6 @@ let &l:path = &l:path . "," . join(
             \ sort(glob("~/.zef/store/*/*/lib", 0, 1), "s:compareReverseFtime"),
             \ ',')
 
-" Convert ascii-based ops into their single-character unicode equivalent
-if get(g:, 'raku_unicode_abbrevs', 0)
-    iabbrev <buffer> !(<) ⊄
-    iabbrev <buffer> !(<=) ⊈
-    iabbrev <buffer> !(>) ⊅
-    iabbrev <buffer> !(>=) ⊉
-    iabbrev <buffer> !(cont) ∌
-    iabbrev <buffer> !(elem) ∉
-    iabbrev <buffer> != ≠
-    iabbrev <buffer> (&) ∩
-    iabbrev <buffer> (+) ⊎
-    iabbrev <buffer> (-) ∖
-    iabbrev <buffer> (.) ⊍
-    iabbrev <buffer> (<) ⊂
-    iabbrev <buffer> (<+) ≼
-    iabbrev <buffer> (<=) ⊆
-    iabbrev <buffer> (>) ⊃
-    iabbrev <buffer> (>+) ≽
-    iabbrev <buffer> (>=) ⊇
-    iabbrev <buffer> (\|) ∪
-    iabbrev <buffer> (^) ⊖
-    iabbrev <buffer> (atomic) ⚛
-    iabbrev <buffer> (cont) ∋
-    iabbrev <buffer> (elem) ∈
-    iabbrev <buffer> * ×
-    iabbrev <buffer> **0 ⁰
-    iabbrev <buffer> **1 ¹
-    iabbrev <buffer> **2 ²
-    iabbrev <buffer> **3 ³
-    iabbrev <buffer> **4 ⁴
-    iabbrev <buffer> **5 ⁵
-    iabbrev <buffer> **6 ⁶
-    iabbrev <buffer> **7 ⁷
-    iabbrev <buffer> **8 ⁸
-    iabbrev <buffer> **9 ⁹
-    iabbrev <buffer> ... …
-    iabbrev <buffer> / ÷
-    iabbrev <buffer> << «
-    iabbrev <buffer> <<[=]<< «=«
-    iabbrev <buffer> <<[=]>> «=»
-    iabbrev <buffer> <= ≤
-    iabbrev <buffer> =~= ≅
-    iabbrev <buffer> >= ≥
-    iabbrev <buffer> >> »
-    iabbrev <buffer> >>[=]<< »=«
-    iabbrev <buffer> >>[=]>> »=»
-    iabbrev <buffer> Inf ∞
-    iabbrev <buffer> atomic-add-fetch ⚛+=
-    iabbrev <buffer> atomic-assign ⚛=
-    iabbrev <buffer> atomic-fetch ⚛
-    iabbrev <buffer> atomic-dec-fetch --⚛
-    iabbrev <buffer> atomic-fetch-dec ⚛--
-    iabbrev <buffer> atomic-fetch-inc ⚛++
-    iabbrev <buffer> atomic-inc-fetch ++⚛
-    iabbrev <buffer> atomic-sub-fetch ⚛−=
-    iabbrev <buffer> e 𝑒
-    iabbrev <buffer> o ∘
-    iabbrev <buffer> pi π
-    iabbrev <buffer> set() ∅
-    iabbrev <buffer> tau τ
-endif
-
 " Undo the stuff we changed.
 let b:undo_ftplugin = "setlocal fo< com< cms< inc< inex< def< isf< isk< kp< path<" .
         \         " | unlet! b:browsefilter"


### PR DESCRIPTION
It's best to have the end user add these manually, rather than maintain
them in the plugin.

The documentation for them remains useful, I think.

I've modified the documented definition for × and ÷ to require a
trailing '+' character, which I believe should make them less obtrusive
but still accessible. Of course, a user can use whatever they like if we
are not defining them ourselves.

Closes #20