### PR TITLE
doc/tags is generated, so let's ignore it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
When loading this vim package, a tags file may be generated in
the doc directory. Let's not track it in git! This is so the
checked-out repository (or submodule) stays as "unmodified"
in git, even if it's in use by vim.