### PR TITLE
Set keywordprg=rakudoc

### DIFF
--- a/ftplugin/raku.vim
+++ b/ftplugin/raku.vim
@@ -18,7 +18,11 @@ set cpo-=C
 
 setlocal formatoptions-=t
 setlocal formatoptions+=crqol
-setlocal keywordprg=p6doc
+if executable('p6doc') && !executable('rakudoc')
+    setlocal keywordprg=p6doc
+else
+    setlocal keywordprg=rakudoc
+endif
 
 setlocal comments=:#\|,:#=,:#
 setlocal commentstring=#%s


### PR DESCRIPTION
Falls back to p6doc if rakudoc is not available, but p6doc is available,
in case someone has the old version installed and not the new one.